### PR TITLE
Fix SSR build error from react-lottie-player

### DIFF
--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -1,8 +1,9 @@
 import { motion, useAnimation } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import React, { useEffect } from "react";
-import Lottie from "react-lottie-player";
+import dynamic from "next/dynamic";
 import animationData from "@lottie/boy-vr.json";
+const Lottie = dynamic(() => import("react-lottie-player"), { ssr: false });
 import { container, introListVariant } from "util/variants";
 
 const Intro: React.FC = () => {

--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -2,8 +2,10 @@ import { motion, useAnimation } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import React, { useEffect } from "react";
 import dynamic from "next/dynamic";
+import type LottieType from "react-lottie-player";
+import type { ComponentProps } from "react";
 import animationData from "@lottie/boy-vr.json";
-const Lottie = dynamic(() => import("react-lottie-player"), { ssr: false });
+const Lottie = dynamic<ComponentProps<typeof LottieType>>(() => import("react-lottie-player"), { ssr: false });
 import { container, introListVariant } from "util/variants";
 
 const Intro: React.FC = () => {

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,8 +3,10 @@ import Link from "next/link";
 import { faGithub, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import dynamic from "next/dynamic";
+import type LottieType from "react-lottie-player";
+import type { ComponentProps } from "react";
 import animationData from "@lottie/40209-hamburger-with-colors.json";
-const Lottie = dynamic(() => import("react-lottie-player"), { ssr: false });
+const Lottie = dynamic<ComponentProps<typeof LottieType>>(() => import("react-lottie-player"), { ssr: false });
 
 interface Props {
 	open: boolean;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,8 +2,9 @@ import React, { useState } from "react";
 import Link from "next/link";
 import { faGithub, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Lottie from "react-lottie-player";
+import dynamic from "next/dynamic";
 import animationData from "@lottie/40209-hamburger-with-colors.json";
+const Lottie = dynamic(() => import("react-lottie-player"), { ssr: false });
 
 interface Props {
 	open: boolean;

--- a/components/NavbarOverlay.tsx
+++ b/components/NavbarOverlay.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { faGithub, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Lottie from "react-lottie-player";
+import dynamic from "next/dynamic";
 import animationData from "@lottie/49075-cube-loader-representing-module-or-logic.json";
+const Lottie = dynamic(() => import("react-lottie-player"), { ssr: false });
 import { motion } from "framer-motion";
 import { container, defaultVariant, overlayListVariant } from "util/variants";
 

--- a/components/NavbarOverlay.tsx
+++ b/components/NavbarOverlay.tsx
@@ -3,8 +3,10 @@ import { faGithub, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import dynamic from "next/dynamic";
+import type LottieType from "react-lottie-player";
+import type { ComponentProps } from "react";
 import animationData from "@lottie/49075-cube-loader-representing-module-or-logic.json";
-const Lottie = dynamic(() => import("react-lottie-player"), { ssr: false });
+const Lottie = dynamic<ComponentProps<typeof LottieType>>(() => import("react-lottie-player"), { ssr: false });
 import { motion } from "framer-motion";
 import { container, defaultVariant, overlayListVariant } from "util/variants";
 


### PR DESCRIPTION
## Summary

- `lottie-web` accesses `window` at import time, crashing Next.js static page generation with `ReferenceError: window is not defined`
- Replaced static `import Lottie from "react-lottie-player"` with `next/dynamic` + `ssr: false` in `Intro`, `Navbar`, and `NavbarOverlay` components
- Also removes age (18) from About section and updates year to sophomore

## Test plan

- [ ] Vercel build passes without `ReferenceError: window is not defined`
- [ ] Lottie animations still render correctly in the browser
- [ ] Navbar hamburger animation works as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP7dLBTi45uS4hkt8bzxZD)_